### PR TITLE
Fix call.remote setter

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -377,22 +377,19 @@ class call {
   */
 
   /**
-  @typedef callerid
-  @property { string } id
-  @property { string } name
-  */
-
-  /**
-   * Sets caller id name or id
+   * Sets caller id
    * @param { callerid } rem
    */
-  set remote( rem ) {
+  setremoteid( callerid ) {
+      this._remote.id = callerid
+  }
 
-    for( const key in this._remote ) {
-      if( rem[ key ] in rem ) {
-        this._remote[ key ] = rem[ key ]
-      }
-    }
+  /**
+   * Sets caller id name
+   * @param { calleridname } rem
+   */
+  setremotename( calleridname ) {
+        this._remote.name = calleridname
   }
 
   /**

--- a/test/unit/call.js
+++ b/test/unit/call.js
@@ -1,0 +1,32 @@
+const expect = require( "chai" ).expect
+const callstore = require( "../../lib/call.js" )
+const srf = require( "../mock/srf.js" )
+
+describe( "call.js", function() {
+
+  it( `set remote name and id`, async function() {
+    let srfscenario = new srf.srfscenario()
+
+    let newcallcalled = false
+    srfscenario.options.em.on( "call.new", ( /*newcall*/ ) => {
+      newcallcalled = true
+    } )
+
+    let call = await new Promise( ( resolve ) => {
+      srfscenario.oncall( async ( call ) => { resolve( call ) } )
+      srfscenario.inbound()
+    } )
+
+    call.setremotename("foo")
+    call.setremoteid("123456789")
+
+    expect(call._remote.name).equals("foo")
+    expect(call._remote.id).equals("123456789")
+
+    // TODO we set the remote id using "setremoteid", but getter returns it as "user" 
+    // the names mismatch and can be confusing, we might consider some polishing here?
+    expect(call.remote.name).equals("foo")
+    expect(call.remote.user).equals("123456789")
+} )
+
+} )


### PR DESCRIPTION
Since we set a getter to the remote property, we want specialized setter methods to properly modify the caller name and id values.

Helps with babblevoice/babble-sip#35