### PR TITLE
parsed name from headers

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -474,13 +474,12 @@ class call {
    * @returns { object }
    */
   #getremotefromheaders() {
-    let parsed
+    let parsed = {}
     if( this._req.has( "p-asserted-identity" ) ) {
       parsed = this._req.getParsedHeader( "p-asserted-identity" )
     } else if( this._req.has( "remote-party-id" ) ) {
       parsed = this._req.getParsedHeader( "remote-party-id" )
-    }
-    if ( this._req.has( "from" ) ) {
+    } else if ( this._req.has( "from" ) ) {
       const from = this._req.getParsedHeader( "from" )
       if ( from.name ) parsed.name = from.name
     }

--- a/lib/call.js
+++ b/lib/call.js
@@ -480,6 +480,10 @@ class call {
     } else if( this._req.has( "remote-party-id" ) ) {
       parsed = this._req.getParsedHeader( "remote-party-id" )
     }
+    if ( this._req.has( "from" ) ) {
+      const from = this._req.getParsedHeader( "from" )
+      if ( from.name ) parsed.name = from.name
+    }
     return parsed
   }
 
@@ -492,7 +496,10 @@ class call {
 
   #fixparseduriobj( parsed ) {
 
+    let name
     if( !parsed ) parsed = {}
+    if( parsed.name ) name = parsed.name
+
     if( !parsed.uri && parsed.user && parsed.host ) parsed.uri = parsed.user + "@" + parsed.host
     if( parsed.uri && !parsed.user && !parsed.host ) parsed = parseuri( parsed.uri )
 
@@ -500,6 +507,7 @@ class call {
 
     if( !parseduri ) parseduri = { "user": parsed.user, "host": parsed.host }
     if( !parsed.params ) parsed.params = {}
+    if( name ) parsed.name = name
 
     return parsed
   }
@@ -549,6 +557,7 @@ class call {
     if( parsed.uri ) startingpoint.uri = parsed.uri
     if( parsed.user ) startingpoint.user = parsed.user
     if( parsed.host ) startingpoint.host = parsed.host
+    if( parsed.name ) startingpoint.name = parsed.name
   }
 
   #fromcontact( startingpoint ) {


### PR DESCRIPTION
There are headers parsed from this._req. I included the parsing of a name from the FROM header as it is needed for the callist rule per issue #267 in babblesip.