### PR TITLE
Add missing await

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -1239,7 +1239,7 @@ class call {
         return this
       }
 
-      this.channels.audio.mix( this.parent.channels.audio )
+      await this.channels.audio.mix( this.parent.channels.audio )
 
       this._em.emit( "call.mix", this )
       callmanager.options.em.emit( "call.mix", this )
@@ -2438,11 +2438,11 @@ class call {
 
       const ourpromises = []
       if( this.channels.audio ) {
-        this.channels.audio.unmix()
+        await this.channels.audio.unmix()
         ourpromises.push( this.waitforanyevent( { "action": "mix", "event": "finished" }, 0.5 ) )
       }
       if( othercall.channels.audio ) {
-        othercall.channels.audio.unmix()
+        await othercall.channels.audio.unmix()
         ourpromises.push( othercall.waitforanyevent( { "action": "mix", "event": "finished" }, 0.5 ) )
       }
 


### PR DESCRIPTION
* I am of the idea that we should be always synchronous with events written to the RTP server.

Even though the final write will not be blocking, we should probably sync until that point to minimize the chances something is going wrong down the way.
