### PR TITLE
Bug 403 would never work in auth function and problem with snoms

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -1437,10 +1437,12 @@ class call {
     /* we have been requested to auth - so set our state to unauthed */
     this.state.authed = false
 
-    if( this._auth.has( this._req ) ) {
-      /* If the client has included an auth header check it immediatly */
-      if( this._onauth( this._req, this._res ) ) return
-    }
+    /* this will never work as if we get here we will never have sent out a nonce and we don't 
+    share between registrar and call processing, leave out so we send an auth request */
+    //if( this._auth.has( this._req ) ) {
+    /* If the client has included an auth header check it immediatly */
+    //  if( this._onauth( this._req, this._res ) ) return
+    //}
 
     this._timers.auth = setTimeout( () => {
       this._promises.reject.auth( new SipError( hangupcodes.REQUEST_TIMEOUT, "Auth timed out" ) )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.6.16",
+  "version": "3.6.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/babble-drachtio-callmanager",
-      "version": "3.6.16",
+      "version": "3.6.17",
       "license": "MIT",
       "dependencies": {
         "@babblevoice/babble-drachtio-auth": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.6.16",
+  "version": "3.6.17",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Snoms attempt to authenticate by reusing the nonce supplied in the registration. We keep the auths (and nonces) separate, so we should always send out a request for a new one.

Where we send out the 403 there would never be an opportunity to actually work as we would never have sent out a nonce for it - so can safely remove.