### PR TITLE
Bug un-handled exception if auth reject gone

### DIFF
--- a/lib/call.js
+++ b/lib/call.js
@@ -1456,15 +1456,21 @@ class call {
       return
     }
 
+    const authtimeoutms = 10000
     this._timers.auth = setTimeout( () => {
-      this._promises.reject.auth( new SipError( hangupcodes.REQUEST_TIMEOUT, "Auth timed out" ) )
+      /* something has overtaken events and cleaned us up already */
+      if( !this._promises.reject ) return
+      if( !this._promises.reject.auth ) return
+
+      const rej = this._promises.reject.auth
       this._promises.resolve.auth = undefined
       this._promises.reject.auth = undefined
       this._timers.auth = undefined
 
+      rej( new SipError( hangupcodes.REQUEST_TIMEOUT, "Auth timed out" ) )
       this.hangup( hangupcodes.REQUEST_TIMEOUT )
 
-    }, 50000 )
+    }, authtimeoutms )
 
     const authpromise = new Promise( ( resolve, reject ) => {
       this._promises.resolve.auth = resolve

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/babble-drachtio-callmanager",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "MIT",
       "dependencies": {
         "@babblevoice/babble-drachtio-auth": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-callmanager",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Call processing to create a PBX",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If the auth timeout fires - the reject might be tidied up elsewhere - this has show up on a container and threw an unhandled exception.